### PR TITLE
Add project hub landing page and rename KML viewer

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>El Sargento Project Hub</title>
+  <meta name="viewport" content="width=device-width,initial-scale=1" />
+  <style>
+    body{font-family:system-ui, sans-serif;margin:0;padding:2rem}
+    nav a{margin-right:1rem;text-decoration:none;color:#2563eb}
+  </style>
+</head>
+<body>
+  <h1>El Sargento – project hub</h1>
+  <nav>
+    <a href="index.html">Home</a>
+    <a href="kml.html">Parcel Map</a>
+    <a href="README.md">Brain Map</a>
+  </nav>
+  <p>Use the links above to explore the repo’s live views.</p>
+</body>
+</html>

--- a/kml.html
+++ b/kml.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Parcel Map</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+  <style>
+    html, body, #map { height: 100%; margin: 0; }
+  </style>
+</head>
+<body>
+  <div id="map"></div>
+  <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
+  <script src="https://unpkg.com/leaflet-omnivore@0.3.4/leaflet-omnivore.min.js"></script>
+  <script>
+    var map = L.map('map').setView([0, 0], 2);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      attribution: '&copy; OpenStreetMap contributors'
+    }).addTo(map);
+    omnivore.kml('poligono-244ha.kml', null, L.geoJSON(null, {
+      style: { color: '#7C3AED', weight: 2, fillOpacity: 0.3 }
+    })).on('ready', function() {
+      map.fitBounds(this.getBounds());
+    }).addTo(map);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add `index.html` with links to README and Parcel Map
- expose KML viewer via `kml.html`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68531e2d1df88333887155afa68e58f3