### PR TITLE
Load + outline parcel with togeojson (fix KML error)

### DIFF
--- a/kml.html
+++ b/kml.html
@@ -12,7 +12,7 @@
 <body>
   <div id="map"></div>
   <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
-  <script src="https://unpkg.com/leaflet-omnivore@0.3.4/leaflet-omnivore.min.js"></script>
+  <script src="https://unpkg.com/togeojson@0.16.0/dist/togeojson.umd.js"></script>
   <script>
     const kmlUrl = 'parcel.kml';
     var map = L.map('map').setView([0, 0], 2);
@@ -22,14 +22,15 @@
     // ---------- KML layer
     const parcelStyle = { color: '#FF007C', weight: 3, fillOpacity: 0.25 };
 
-    omnivore.kml(kmlUrl)
-      .on('ready', function () {
-        // Style each feature and zoom to it
-        this.eachLayer(layer => layer.setStyle(parcelStyle));
-        map.fitBounds(this.getBounds());
+    fetch(kmlUrl)
+      .then(res => res.text())
+      .then(text => {
+        const dom = new DOMParser().parseFromString(text, 'text/xml');
+        const geojson = toGeoJSON.kml(dom);
+        const layer = L.geoJSON(geojson, { style: parcelStyle }).addTo(map);
+        map.fitBounds(layer.getBounds());
       })
-      .on('error', () => alert('Failed to load KML layer.'))
-      .addTo(map);
+      .catch(() => alert('Failed to load KML layer.'));
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- link in togeojson on the KML viewer page
- fetch the parcel KML and convert it to GeoJSON

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685328d13f948333b44c7a188eb820aa