### PR TITLE
Switch KmlViewer basemap to satellite imagery

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -1,3 +1,4 @@
 | Date | task | description | status | notes |
 | ---- | ---- | ----------- | ------ | ----- |
 | 2025-06-18 | kml-viewer | Initial KML overlay page | 🟡 In Progress | layer toggle |
+| 2025-06-19 | kml-viewer | Swap OSM → satellite | 🟡 In Progress | verify Esri tiles load |

--- a/src/pages/KmlViewer.tsx
+++ b/src/pages/KmlViewer.tsx
@@ -15,8 +15,8 @@ export default function KmlViewer() {
       zoom={2}
     >
       <TileLayer
-        attribution="&copy; OpenStreetMap contributors"
-        url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+        attribution="Tiles © Esri — Source: Esri, Maxar, Earthstar, GeoEye"
+        url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
       />
       <KmlLayer />
     </MapContainer>

--- a/src/pages/__tests__/KmlViewer.test.tsx
+++ b/src/pages/__tests__/KmlViewer.test.tsx
@@ -12,7 +12,7 @@ jest.mock('react-leaflet', () => {
   const React = require('react');
   return {
     MapContainer: ({ children }: any) => <div data-testid="map">{children}</div>,
-    TileLayer: () => null,
+    TileLayer: (props: any) => <div data-testid="tile" {...props} />,
     useMap: () => ({ fitBounds: jest.fn(), addLayer: jest.fn(), removeLayer: jest.fn() })
   };
 });
@@ -33,4 +33,8 @@ test('renders page and loads KML', () => {
   });
   expect(screen.getByTestId('map')).toBeInTheDocument();
   expect(addTo).toHaveBeenCalled();
+  expect(screen.getByTestId('tile')).toHaveAttribute(
+    'url',
+    'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
+  );
 });

--- a/src/stories/KmlViewer.stories.tsx
+++ b/src/stories/KmlViewer.stories.tsx
@@ -1,0 +1,13 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import KmlViewer from '../pages/KmlViewer';
+
+const meta: Meta<typeof KmlViewer> = {
+  title: 'KmlViewer',
+  component: KmlViewer,
+};
+export default meta;
+
+export const SatelliteOutline: StoryObj<typeof KmlViewer> = {
+  name: 'Satellite + Outline',
+  render: () => <KmlViewer />,
+};


### PR DESCRIPTION
## Summary
- load Esri World Imagery in `KmlViewer`
- show tile URL in tests
- add a Storybook entry named "Satellite + Outline"
- log update in `STATUS.md`

## Testing
- `npm test`
- `npm run lint` *(fails: Missing script)*
- `npm run storybook --quiet` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68538be917e08333a4fa9eece745f29a