### PR TITLE
Fix KML path resolution

### DIFF
--- a/src/pages/KmlViewer.tsx
+++ b/src/pages/KmlViewer.tsx
@@ -5,7 +5,9 @@ import * as L from "leaflet";
 import omnivore from "@mapbox/leaflet-omnivore";
 import { useSnackbar } from "notistack";
 
-const KML_PATH = "/poligono-244ha.kml";
+// Use a relative path so deployments under a subfolder work (e.g. GitHub Pages)
+// without 404 errors when loading the KML file.
+const KML_PATH = "poligono-244ha.kml";
 
 export default function KmlViewer() {
   return (


### PR DESCRIPTION
## Summary
- fix incorrect absolute path causing 404 errors when loading `poligono-244ha.kml`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68538ceaae0c83338376f52d64da5d71