### PR TITLE
Add KML load failure test

### DIFF
--- a/src/pages/__tests__/KmlViewer.test.tsx
+++ b/src/pages/__tests__/KmlViewer.test.tsx
@@ -38,3 +38,29 @@ test('renders page and loads KML', () => {
     'https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}'
   );
 });
+
+test('displays snackbar when KML fails to load', () => {
+  const addTo = jest.fn().mockReturnThis();
+  const on = jest.fn((event: string, cb: any) => {
+    if (event === 'error') {
+      cb(new Error('404'));
+    }
+    return { on, addTo };
+  });
+  (omnivore as any).kml.mockReturnValue({ on, addTo });
+
+  const enqueueSnackbar = jest.fn();
+  jest.spyOn(require('notistack'), 'useSnackbar').mockReturnValue({ enqueueSnackbar });
+
+  act(() => {
+    render(
+      <MemoryRouter>
+        <SnackbarProvider>
+          <KmlViewer />
+        </SnackbarProvider>
+      </MemoryRouter>
+    );
+  });
+
+  expect(enqueueSnackbar).toHaveBeenCalledWith('Failed to load KML layer', { variant: 'error' });
+});


### PR DESCRIPTION
## Summary
- check KmlViewer shows an error snackbar when the KML file fails to load

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68538f5542e88333bdab487852df1a8e