### PR TITLE
Add initial AmenityLayer with three markers at parcel centroid

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -2,3 +2,4 @@
 | ---- | ---- | ----------- | ------ | ----- |
 | 2025-06-18 | kml-viewer | Initial KML overlay page | 🟡 In Progress | layer toggle |
 | 2025-06-19 | kml-viewer | Swap OSM → satellite | 🟢 Done | Esri world imagery now default |
+| 2025-06-19 | amenities | Add AmenityLayer & centroid placement | 🟡 In Progress | refine icon art |

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -1,0 +1,35 @@
+import React from "react";
+import { MapContainer, TileLayer } from "react-leaflet";
+import { FeatureCollection } from "geojson";
+import centerOfMass from "@turf/center-of-mass";
+import { amenities, Amenity } from "../data/amenities";
+import { AmenityLayer } from "../layers/AmenityLayer";
+import { ParcelLayer } from "../layers/ParcelLayer";
+
+export default function Map({ showParcel = true, showAmenities = true }: { showParcel?: boolean; showAmenities?: boolean }) {
+  const [amenityData, setAmenityData] = React.useState<Amenity[]>(amenities);
+  const initialized = React.useRef(false);
+
+  const handleParcelLoad = (geojson: FeatureCollection) => {
+    if (initialized.current) return;
+    const centroid = centerOfMass(geojson);
+    const [lng, lat] = centroid.geometry.coordinates;
+    const updated = amenities.map((a) => ({
+      ...a,
+      geometry: { ...a.geometry, coordinates: [lng, lat] },
+    }));
+    setAmenityData(updated);
+    initialized.current = true;
+  };
+
+  return (
+    <MapContainer style={{ height: "100vh", width: "100vw" }} center={[0, 0]} zoom={2}>
+      <TileLayer
+        attribution="Tiles © Esri — Source: Esri, Maxar, Earthstar, GeoEye"
+        url="https://server.arcgisonline.com/ArcGIS/rest/services/World_Imagery/MapServer/tile/{z}/{y}/{x}"
+      />
+      {showAmenities && <AmenityLayer data={amenityData} />}
+      {showParcel && <ParcelLayer onLoad={handleParcelLoad} />}
+    </MapContainer>
+  );
+}

--- a/src/data/amenities.ts
+++ b/src/data/amenities.ts
@@ -1,0 +1,27 @@
+import { Feature, Point } from "geojson";
+
+export interface Amenity extends Feature<Point> {
+  properties: {
+    id: string;
+    name: string;
+    type: "clubhouse" | "pool" | "parking";
+  };
+}
+
+export const amenities: Amenity[] = [
+  {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties: { id: "clubhouse-hub", name: "Clubhouse", type: "clubhouse" },
+  },
+  {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties: { id: "pool-hub", name: "Pool", type: "pool" },
+  },
+  {
+    type: "Feature",
+    geometry: { type: "Point", coordinates: [0, 0] },
+    properties: { id: "parking-hub", name: "Parking", type: "parking" },
+  },
+];

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,1 @@
+@import "./styles/amenities.css";

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { createRoot } from 'react-dom/client';
 import App from './App';
 import { SnackbarProvider } from 'notistack';
+import './index.css';
 
 const root = createRoot(document.getElementById('root')!);
 root.render(

--- a/src/layers/AmenityLayer.tsx
+++ b/src/layers/AmenityLayer.tsx
@@ -1,0 +1,19 @@
+import * as L from "leaflet";
+import { Marker, Tooltip } from "react-leaflet";
+import { Amenity } from "../data/amenities";
+
+export function AmenityLayer({ data }: { data: Amenity[] }) {
+  return (
+    <>
+      {data.map((f) => (
+        <Marker
+          key={f.properties.id}
+          position={[f.geometry.coordinates[1], f.geometry.coordinates[0]]}
+          icon={L.divIcon({ className: `amenity-${f.properties.type}` })}
+        >
+          <Tooltip>{f.properties.name}</Tooltip>
+        </Marker>
+      ))}
+    </>
+  );
+}

--- a/src/layers/ParcelLayer.tsx
+++ b/src/layers/ParcelLayer.tsx
@@ -1,0 +1,36 @@
+import React from "react";
+import { useMap } from "react-leaflet";
+import omnivore from "@mapbox/leaflet-omnivore";
+import * as L from "leaflet";
+import { FeatureCollection } from "geojson";
+
+export function ParcelLayer({ onLoad, kmlPath = "parcel.kml" }: { onLoad?: (geojson: FeatureCollection) => void; kmlPath?: string }) {
+  const map = useMap();
+
+  React.useEffect(() => {
+    const style = { color: "#FF007C", weight: 3, fillOpacity: 0.25 };
+    const layer = omnivore
+      .kml(kmlPath, null, L.geoJSON(null, { style }))
+      .on("ready", () => {
+        try {
+          const geojson = layer.toGeoJSON() as FeatureCollection;
+          onLoad?.(geojson);
+          const bounds = (layer as any).getBounds?.();
+          if (bounds && (bounds.isValid ? bounds.isValid() : true)) {
+            map.fitBounds(bounds);
+          }
+        } catch (err) {
+          console.error("[ParcelLayer] Error while processing KML:", err);
+        }
+      })
+      .on("error", (err: any) => {
+        console.error("[ParcelLayer] Failed to load KML layer:", err);
+      })
+      .addTo(map);
+    return () => {
+      map.removeLayer(layer);
+    };
+  }, [map, onLoad, kmlPath]);
+
+  return null;
+}

--- a/src/stories/Map.stories.tsx
+++ b/src/stories/Map.stories.tsx
@@ -1,0 +1,43 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import React from 'react';
+import Map from '../components/Map';
+
+const meta: Meta<typeof Map> = {
+  title: 'Map',
+  component: Map,
+};
+export default meta;
+
+export const Basic: StoryObj<typeof Map> = {
+  name: 'Basic',
+  render: () => <Map />,
+};
+
+export const Amenities: StoryObj<typeof Map> = {
+  name: 'Amenities',
+  render: () => {
+    const [showParcel, setShowParcel] = React.useState(true);
+    const [showAmenities, setShowAmenities] = React.useState(true);
+    return (
+      <div>
+        <label style={{ position: 'absolute', zIndex: 1000 }}>
+          <input
+            type="checkbox"
+            checked={showParcel}
+            onChange={(e) => setShowParcel(e.target.checked)}
+          />{' '}
+          Show Parcel
+        </label>
+        <label style={{ position: 'absolute', left: '150px', zIndex: 1000 }}>
+          <input
+            type="checkbox"
+            checked={showAmenities}
+            onChange={(e) => setShowAmenities(e.target.checked)}
+          />{' '}
+          Show Amenities
+        </label>
+        <Map showParcel={showParcel} showAmenities={showAmenities} />
+      </div>
+    );
+  },
+};

--- a/src/styles/amenities.css
+++ b/src/styles/amenities.css
@@ -1,0 +1,3 @@
+.leaflet-marker-icon.amenity-clubhouse { background:#623cea;border-radius:50%;width:14px;height:14px; }
+.leaflet-marker-icon.amenity-pool      { background:#1fa3ff;border-radius:50%;width:14px;height:14px; }
+.leaflet-marker-icon.amenity-parking   { background:#666;border-radius:50%;width:14px;height:14px; }


### PR DESCRIPTION
## Summary
- create amenity dataset with placeholder coordinates
- show amenities on map with new AmenityLayer and styling
- compute centroid from ParcelLayer KML and place amenity markers there
- expose `showParcel` and `showAmenities` props for toggling layers
- add matching Storybook entry and import amenity CSS
- log progress in STATUS

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685432ee7d3c8333b402a0b55d8612dd