### PR TITLE
Fix AmenityLayer visibility — correct divIcon & ensure centroid state update

### DIFF
--- a/STATUS.md
+++ b/STATUS.md
@@ -3,3 +3,4 @@
 | 2025-06-18 | kml-viewer | Initial KML overlay page | 🟡 In Progress | layer toggle |
 | 2025-06-19 | kml-viewer | Swap OSM → satellite | 🟢 Done | Esri world imagery now default |
 | 2025-06-19 | amenities | Add AmenityLayer & centroid placement | 🟡 In Progress | refine icon art |
+| 2025-MM-DD | amenities | fix icon helper & state update | 🟡 In Progress | verify marker drag logic |

--- a/src/components/Map.tsx
+++ b/src/components/Map.tsx
@@ -11,15 +11,13 @@ export default function Map({ showParcel = true, showAmenities = true }: { showP
   const initialized = React.useRef(false);
 
   const handleParcelLoad = (geojson: FeatureCollection) => {
-    if (initialized.current) return;
-    const centroid = centerOfMass(geojson);
-    const [lng, lat] = centroid.geometry.coordinates;
-    const updated = amenities.map((a) => ({
-      ...a,
-      geometry: { ...a.geometry, coordinates: [lng, lat] },
-    }));
-    setAmenityData(updated);
-    initialized.current = true;
+    if (!initialized.current) {
+      const centroid = centerOfMass(geojson);
+      const [lng, lat] = centroid.geometry.coordinates;
+      amenities.forEach((a) => (a.geometry.coordinates = [lng, lat]));
+      setAmenityData([...amenities]);
+      initialized.current = true;
+    }
   };
 
   return (

--- a/src/layers/AmenityLayer.tsx
+++ b/src/layers/AmenityLayer.tsx
@@ -1,5 +1,5 @@
-import * as L from "leaflet";
 import { Marker, Tooltip } from "react-leaflet";
+import { divIcon } from "leaflet";
 import { Amenity } from "../data/amenities";
 
 export function AmenityLayer({ data }: { data: Amenity[] }) {
@@ -9,7 +9,10 @@ export function AmenityLayer({ data }: { data: Amenity[] }) {
         <Marker
           key={f.properties.id}
           position={[f.geometry.coordinates[1], f.geometry.coordinates[0]]}
-          icon={L.divIcon({ className: `amenity-${f.properties.type}` })}
+          icon={divIcon({
+            className: `leaflet-marker-icon amenity-${f.properties.type}`,
+            iconSize: [14, 14],
+          })}
         >
           <Tooltip>{f.properties.name}</Tooltip>
         </Marker>

--- a/src/styles/amenities.css
+++ b/src/styles/amenities.css
@@ -1,3 +1,9 @@
-.leaflet-marker-icon.amenity-clubhouse { background:#623cea;border-radius:50%;width:14px;height:14px; }
-.leaflet-marker-icon.amenity-pool      { background:#1fa3ff;border-radius:50%;width:14px;height:14px; }
-.leaflet-marker-icon.amenity-parking   { background:#666;border-radius:50%;width:14px;height:14px; }
+
+.leaflet-marker-icon.amenity-clubhouse,
+.leaflet-div-icon.amenity-clubhouse { background:#623cea;border-radius:50%;width:14px;height:14px; }
+
+.leaflet-marker-icon.amenity-pool,
+.leaflet-div-icon.amenity-pool      { background:#1fa3ff;border-radius:50%;width:14px;height:14px; }
+
+.leaflet-marker-icon.amenity-parking,
+.leaflet-div-icon.amenity-parking   { background:#666;border-radius:50%;width:14px;height:14px; }


### PR DESCRIPTION
## Summary
- use Leaflet's `divIcon` helper in `AmenityLayer`
- trigger amenity state update once centroid is computed
- broaden CSS selectors for amenity markers
- update project status log

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6854356e8ea08333891030cc0b025ace